### PR TITLE
Setup TypeScript and Jest configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+*.log
+.DS_Store
+coverage/

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/*.test.ts'],
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/**/*.test.ts'
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "autodev-test",
+  "version": "1.0.0",
+  "description": "Test repository for AutoDev system",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.0",
+    "@types/node": "^20.0.0",
+    "jest": "^29.5.0",
+    "ts-jest": "^29.1.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "node",
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
Adds TypeScript and Jest configuration to enable autodev's typecheck and test validation.

## Changes
- ✅ Added `package.json` with TypeScript 5.x, Jest 29.x, and type definitions
- ✅ Added `tsconfig.json` with strict mode and ES2020 target
- ✅ Added `jest.config.js` for ts-jest preset
- ✅ Added `.gitignore` for node_modules and build artifacts

## Why
The autodev-test repository had TypeScript files but no configuration, causing typecheck validation to fail on all PRs. This PR fixes that by adding the necessary build tooling.

## Testing
After merging, autodev will be able to:
- Run `npm run typecheck` (or `npx tsc --noEmit`) successfully
- Run `npm test` to execute Jest tests
- Validate PRs before merging